### PR TITLE
passing source to anonymous goroutine as parameter

### DIFF
--- a/sources.go
+++ b/sources.go
@@ -15,7 +15,6 @@ type StaticSource map[uint64][]string
 
 func (s StaticSource) GetID() string {
 	return "static"
-
 }
 
 func (s StaticSource) GetChainIDs() []uint64 {

--- a/tokendirectory.go
+++ b/tokendirectory.go
@@ -115,10 +115,10 @@ func (f *TokenDirectory) updateSources(ctx context.Context) error {
 	for _, source := range f.sources {
 		for _, chainID := range source.GetChainIDs() {
 			wg.Add(1)
-			go func(chainID uint64) {
+			go func(chainID uint64, source Source) {
 				defer wg.Done()
 				f.updateChainSource(ctx, source, chainID)
-			}(chainID)
+			}(chainID, source)
 		}
 	}
 	wg.Wait()

--- a/types.go
+++ b/types.go
@@ -18,7 +18,7 @@ type ContractInfo struct {
 	ChainID uint64 `json:"chainId"`
 	Address string `json:"address"`
 	Name    string `json:"name"`
-	//Standard   string `json:"standard"`
+	// Standard   string `json:"standard"`
 	Type       string `json:"type"` // NOTE: a duplicate of standard to normalize with other Sequence payloads
 	Symbol     string `json:"symbol,omitempty"`
 	Decimals   uint64 `json:"decimals"`


### PR DESCRIPTION
Missing passing source to anonymous goroutine as parameter.

In go.mod we have version 1.18
Since 1.22 this wouldn't be an issue anymore: https://antonz.org/go-1-22/#no-more-sharing-of-loop-variables